### PR TITLE
Fix bpb styles.

### DIFF
--- a/Formula/bpb.rb
+++ b/Formula/bpb.rb
@@ -5,17 +5,16 @@ class Bpb < Formula
   version "1.2.0"
   sha256 "d24cf6c09e7497e5b38d85b6d52d51be9209163e44ac253ada6a84d801db5326"
 
+  bottle do
+    root_url "https://github.com/indirect/homebrew-tap/releases/download/bpb-v1.2.0"
+    sha256 cellar: :any_skip_relocation, arm64_big_sur: "f947366c4bb526a4c1d80d63dfca4b50ada8326279e738c47c375f1cc25d3bd8"
+    sha256 cellar: :any_skip_relocation, big_sur:       "7232cdecdf15817783ade2e1162e64d1937a3401fc6d799de733e348c451b509"
+  end
+
   depends_on "rust" => :build
 
   def install
     system "cargo", "install", "--path", ".", "--root", prefix
-  end
-
-  bottle do
-    root_url "https://github.com/indirect/homebrew-tap/releases/download/bpb-v1.2.0"
-    cellar :any_skip_relocation
-    sha256 "7232cdecdf15817783ade2e1162e64d1937a3401fc6d799de733e348c451b509" => :big_sur
-    sha256 "f947366c4bb526a4c1d80d63dfca4b50ada8326279e738c47c375f1cc25d3bd8" => :arm64_big_sur
   end
 
   test do


### PR DESCRIPTION
Got a bunch of style errors in `brew` operations:

```
Warning: Calling `sha256 "digest" => :tag` in a bottle block is deprecated! Use `brew style --fix` on the formula to update the style or use `sha256 tag: "digest"` instead.
Please report this issue to the indirect/tap tap (not Homebrew/brew or Homebrew/core), or even better, submit a PR to fix it:
  /opt/homebrew/Library/Taps/indirect/homebrew-tap/Formula/bpb.rb:18
```

This should fix that.