### PR TITLE
[ghostty] add zap stanza and link man pages+completions+terminfo entries

### DIFF
--- a/Casks/ghostty.rb
+++ b/Casks/ghostty.rb
@@ -18,6 +18,8 @@ cask "ghostty" do
 
   app "Ghostty.app"
   binary "#{appdir}/Ghostty.app/Contents/MacOS/ghostty"
+  manpage "#{appdir}/Ghostty.app/Contents/Resources/man/man1/ghostty.1"
+  manpage "#{appdir}/Ghostty.app/Contents/Resources/man/man5/ghostty.5"
 
   zap trash: [
     "~/Library/Caches/com.mitchellh.ghostty",

--- a/Casks/ghostty.rb
+++ b/Casks/ghostty.rb
@@ -18,6 +18,8 @@ cask "ghostty" do
 
   app "Ghostty.app"
   binary "#{appdir}/Ghostty.app/Contents/MacOS/ghostty"
+  binary "#{appdir}/Ghostty.app/Contents/Resources/fish/vendor_completions.d/ghostty.fish",
+         target: "#{HOMEBREW_PREFIX}/share/fish/vendor_completions.d/ghostty.fish"
   manpage "#{appdir}/Ghostty.app/Contents/Resources/man/man1/ghostty.1"
   manpage "#{appdir}/Ghostty.app/Contents/Resources/man/man5/ghostty.5"
 

--- a/Casks/ghostty.rb
+++ b/Casks/ghostty.rb
@@ -20,6 +20,10 @@ cask "ghostty" do
   binary "#{appdir}/Ghostty.app/Contents/MacOS/ghostty"
   binary "#{appdir}/Ghostty.app/Contents/Resources/fish/vendor_completions.d/ghostty.fish",
          target: "#{HOMEBREW_PREFIX}/share/fish/vendor_completions.d/ghostty.fish"
+  binary "#{appdir}/Ghostty.app/Contents/Resources/terminfo/67/ghostty",
+         target: "#{ENV.fetch("TERMINFO", "~/.terminfo")}/67/ghostty"
+  binary "#{appdir}/Ghostty.app/Contents/Resources/terminfo/78/xterm-ghostty",
+         target: "#{ENV.fetch("TERMINFO", "~/.terminfo")}/78/xterm-ghostty"
   manpage "#{appdir}/Ghostty.app/Contents/Resources/man/man1/ghostty.1"
   manpage "#{appdir}/Ghostty.app/Contents/Resources/man/man5/ghostty.5"
 

--- a/Casks/ghostty.rb
+++ b/Casks/ghostty.rb
@@ -18,4 +18,12 @@ cask "ghostty" do
 
   app "Ghostty.app"
   binary "#{appdir}/Ghostty.app/Contents/MacOS/ghostty"
+
+  zap trash: [
+    "~/Library/Caches/com.mitchellh.ghostty",
+    "~/Library/HTTPStorages/com.mitchellh.ghostty",
+    "~/Library/Preferences/com.mitchellh.ghostty.plist",
+    "~/Library/Saved Application State/com.mitchellh.ghostty.savedState",
+    "~/Library/WebKit/com.mitchellh.ghostty",
+  ]
 end


### PR DESCRIPTION
I used https://github.com/Homebrew/homebrew-cask/blob/master/Casks/a/alacritty.rb as a reference.

I manually tested the fish completions and `man ghostty`.