### PR TITLE
[ghostty] add name

### DIFF
--- a/Casks/ghostty.rb
+++ b/Casks/ghostty.rb
@@ -3,6 +3,7 @@ cask "ghostty" do
   sha256 :no_check
   depends_on macos: ">= :monterey"
 
+  name "Ghostty"
   desc "GPU-accelerated terminal emulator pushing modern features"
   homepage "https://github.com/mitchellh/ghostty"
   url do


### PR DESCRIPTION
This isn't strictly necessary, but it makes the `brew info` output a bit nicer.

Right now it outputs:
```
==> ghostty: latest (auto_updates)
[...]
==> Name
None
==> Description
GPU-accelerated terminal emulator pushing modern features
```